### PR TITLE
Resolve encode issue and auto link issue

### DIFF
--- a/src/Microsoft.Content.Build.Code2Yaml.ArticleGenerator/BasicArticleGenerator.cs
+++ b/src/Microsoft.Content.Build.Code2Yaml.ArticleGenerator/BasicArticleGenerator.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Net;
     using System.Linq;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
@@ -201,7 +202,7 @@
             {
                 return;
             }
-            yaml.Remarks = node.XPathSelectElement("detaileddescription/para/simplesect[@kind='par']/para").NullableInnerXmlRemoveBr();
+            yaml.Remarks = WebUtility.HtmlDecode(node.XPathSelectElement("detaileddescription/para/simplesect[@kind='par']/para").NullableInnerXmlRemoveBr());
             if (yaml.Remarks == string.Empty)
             {
                 yaml.Remarks = null;

--- a/src/Microsoft.Content.Build.Code2Yaml.ArticleGenerator/BasicArticleGenerator.cs
+++ b/src/Microsoft.Content.Build.Code2Yaml.ArticleGenerator/BasicArticleGenerator.cs
@@ -188,7 +188,7 @@
 
         protected void FillSummary(ArticleItemYaml yaml, XElement node)
         {
-            yaml.Summary = node.NullableElement("briefdescription").NullableInnerXml() + ParseSummaryFromDetailedDescription(node.NullableElement("detaileddescription"));
+            yaml.Summary = WebUtility.HtmlDecode(node.NullableElement("briefdescription").NullableInnerXml() + ParseSummaryFromDetailedDescription(node.NullableElement("detaileddescription")));
             if (yaml.Summary == string.Empty)
             {
                 yaml.Summary = null;

--- a/src/Microsoft.Content.Build.Code2Yaml.Steps/template/DoxyfileTemplate
+++ b/src/Microsoft.Content.Build.Code2Yaml.Steps/template/DoxyfileTemplate
@@ -309,7 +309,7 @@ MARKDOWN_SUPPORT       = NO
 # globally by setting AUTOLINK_SUPPORT to NO.
 # The default value is: YES.
 
-AUTOLINK_SUPPORT       = YES
+AUTOLINK_SUPPORT       = NO
 
 # If you use STL classes (i.e. std::string, std::vector, etc.) but do not want
 # to include (a tag file for) the STL sources as input, then you should set this

--- a/test/code2yaml.Tests/Code2YamlTest.cs
+++ b/test/code2yaml.Tests/Code2YamlTest.cs
@@ -62,13 +62,13 @@ namespace Microsoft.Content.Build.Code2Yaml.Tests
             var outputPath = Path.Combine(outputFolder, "com.mycompany.app._app.yml");
             Assert.True(File.Exists(outputPath));
             var model = YamlUtility.Deserialize<PageModel>(outputPath);
-            Assert.Equal(7, model.Items.Count);
+            Assert.Equal(8, model.Items.Count);
 
             var item = model.Items.Find(i => i.Name == "App");
             Assert.NotNull(item);
             Assert.Equal(MemberType.Class, item.Type);
             Assert.Equal("com.mycompany.app.App", item.FullName);
-            Assert.Equal("<p>\n\n  <xref uid=\"com.mycompany.app._app\" data-throw-if-not-resolved=\"false\">App</xref>'s summary </p>", item.Summary.Replace("\r\n", "\n"));
+            Assert.Equal("<p>\n\n  <xref uid=\"com.mycompany.app._app\" data-throw-if-not-resolved=\"false\">App</xref>'s summary<br />\n\n Escape auto link for <xref uid=\"com.mycompany.app._app\" data-throw-if-not-resolved=\"false\">App</xref> with `%`: App </p>", item.Summary.Replace("\r\n", "\n"));
 
             item = model.Items.Find(i => i.Name == "main(String[] args)");
             Assert.NotNull(item);
@@ -109,6 +109,11 @@ public void checkIndentation() {
         // 8 spaces indentation
 }
 ```".Replace("\r\n", "\n"), item.Remarks.Replace("\r\n", "\n"));
+
+            item = model.Items.Find(i => i.Name == "testNOTEFormat()");
+            Assert.NotNull(item);
+            Assert.Equal(MemberType.Method, item.Type);
+            Assert.Equal(@">[!NOTE]> Here is a Note with a list below:<ul><li><p>item 1</p></li><li><p>item 2 </p></li></ul>", item.Remarks);
         }
 
         public void Dispose()

--- a/test/code2yaml.Tests/Code2YamlTest.cs
+++ b/test/code2yaml.Tests/Code2YamlTest.cs
@@ -62,13 +62,13 @@ namespace Microsoft.Content.Build.Code2Yaml.Tests
             var outputPath = Path.Combine(outputFolder, "com.mycompany.app._app.yml");
             Assert.True(File.Exists(outputPath));
             var model = YamlUtility.Deserialize<PageModel>(outputPath);
-            Assert.Equal(8, model.Items.Count);
+            Assert.Equal(9, model.Items.Count);
 
             var item = model.Items.Find(i => i.Name == "App");
             Assert.NotNull(item);
             Assert.Equal(MemberType.Class, item.Type);
             Assert.Equal("com.mycompany.app.App", item.FullName);
-            Assert.Equal("<p>\n\n  <xref uid=\"com.mycompany.app._app\" data-throw-if-not-resolved=\"false\">App</xref>'s summary<br />\n\n Escape auto link for <xref uid=\"com.mycompany.app._app\" data-throw-if-not-resolved=\"false\">App</xref> with `%`: App </p>", item.Summary.Replace("\r\n", "\n"));
+            Assert.Equal("<p>App's summary </p>", item.Summary.Replace("\r\n", "\n"));
 
             item = model.Items.Find(i => i.Name == "main(String[] args)");
             Assert.NotNull(item);
@@ -114,6 +114,12 @@ public void checkIndentation() {
             Assert.NotNull(item);
             Assert.Equal(MemberType.Method, item.Type);
             Assert.Equal(@">[!NOTE]> Here is a Note with a list below:<ul><li><p>item 1</p></li><li><p>item 2 </p></li></ul>", item.Remarks);
+
+            item = model.Items.Find(i => i.Name == "testEncode()");
+            Assert.NotNull(item);
+            Assert.Equal(MemberType.Method, item.Type);
+            Assert.Equal("<p>Test encode in summary: `<`, `>` </p>", item.Summary);
+            Assert.Equal("In remarks: `<`, `>` \n```Java\n//In code snippet: `<`, `>`\n```", item.Remarks.Replace("\r\n", "\n"));
         }
 
         public void Dispose()

--- a/test/code2yaml.Tests/Code2YamlTest.cs
+++ b/test/code2yaml.Tests/Code2YamlTest.cs
@@ -113,7 +113,7 @@ public void checkIndentation() {
             item = model.Items.Find(i => i.Name == "testNOTEFormat()");
             Assert.NotNull(item);
             Assert.Equal(MemberType.Method, item.Type);
-            Assert.Equal(@">[!NOTE]> Here is a Note with a list below:<ul><li><p>item 1</p></li><li><p>item 2 </p></li></ul>", item.Remarks);
+            Assert.Equal(@">[!NOTE] Here is a Note with a list below:<ul><li><p>item 1</p></li><li><p>item 2 </p></li></ul>", item.Remarks);
 
             item = model.Items.Find(i => i.Name == "testEncode()");
             Assert.NotNull(item);

--- a/test/code2yaml.Tests/TestData/test.java
+++ b/test/code2yaml.Tests/TestData/test.java
@@ -66,7 +66,7 @@ public class App {
     /**
      * @apiNote
      * >[!NOTE]
-     * > Here is a Note with a list below:
+     * Here is a Note with a list below:
      * - item 1
      * - item 2
      */

--- a/test/code2yaml.Tests/TestData/test.java
+++ b/test/code2yaml.Tests/TestData/test.java
@@ -1,7 +1,7 @@
 ﻿package com.mycompany.app;
 
 /**
- * App's summary
+ * App's summary\n Escape auto link for App with `%`: %App
  */
 public class App {
     /**
@@ -61,5 +61,15 @@ public class App {
      * </pre>
      */
     public void testIndentationWithPre() {
+    }
+
+    /**
+     * @apiNote
+     * >[!NOTE]
+     * > Here is a Note with a list below:
+     * - item 1
+     * - item 2
+     */
+    public void testNOTEFormat() {
     }
 }

--- a/test/code2yaml.Tests/TestData/test.java
+++ b/test/code2yaml.Tests/TestData/test.java
@@ -1,7 +1,7 @@
 ﻿package com.mycompany.app;
 
 /**
- * App's summary\n Escape auto link for App with `%`: %App
+ * App's summary
  */
 public class App {
     /**
@@ -71,5 +71,16 @@ public class App {
      * - item 2
      */
     public void testNOTEFormat() {
+    }
+
+    /**
+     * Test encode in summary: `<`, `>`
+     * @apiNote
+     * In remarks: `<`, `>` \n
+     * ```Java\n
+     * //In code snippet: `<`, `>`\n
+     * ```\n
+     */
+    public void testEncode() {
     }
 }


### PR DESCRIPTION
1. resolve encode issue of `<`, `>` with System.Net.WebUtility.HtmlDecode()
2. Update usage of `%` to escape auto-link for the specific word: Need user put `%` in front of the word.


