### PR TITLE
formated file name and ids

### DIFF
--- a/src/Microsoft.Content.Build.Code2Yaml.Constants/Constants.cs
+++ b/src/Microsoft.Content.Build.Code2Yaml.Constants/Constants.cs
@@ -16,6 +16,8 @@
         public const string IntermediateFolderName = ".inter";
         public const string XmlFolderName = "xml";
         public const string ProcessedXmlFolderName = "xml_update";
+        public const string RenamedFormat = "{0}({1})";
+        public const string ExtendedIdMappings = "extended_id_mappings";
         public const string Changes = "changes";
         public const string CurrentChange = "cur_change";
         public const string ParentChange = "parent_change";

--- a/src/Microsoft.Content.Build.Code2Yaml.Steps/PreprocessXml.cs
+++ b/src/Microsoft.Content.Build.Code2Yaml.Steps/PreprocessXml.cs
@@ -54,8 +54,6 @@
                 Directory.Delete(processedOutputPath, recursive: true);
             }
             var dirInfo = Directory.CreateDirectory(processedOutputPath);
-
-            var renamedIds = new ConcurrentDictionary<string, string>();
    
             // workaround for Doxygen Bug: it generated xml whose encoding is ANSI while the xml meta is encoding='UTF-8'
             // preprocess in string level: fix style for type with template parameter
@@ -65,40 +63,9 @@
                     var content = File.ReadAllText(p, Encoding.UTF8);
                     content = TemplateLeftTagRegex.Replace(content, "$1");
                     content = TemplateRightTagRegex.Replace(content, "$1");
-                    XDocument doc = XDocument.Parse(content);
-
-                    //workaround for Doxygen generates hash for long file name: using regularized compounddef name as file name.
-                    var node = doc.Root.NullableElement("compounddef");                                                         
-                    if (!string.IsNullOrEmpty(node.NullableValue()) && !kindsToEscapeRenameCollection.Contains(node.Attribute("kind").Value))
-                    {
-                        var id = node.Attribute("id").Value;
-                        var formatName = YamlUtility.RegularizeName(node.Attribute("kind").Value + node.NullableElement("compoundname").NullableValue(), Constants.IdSpliter);
-
-                        if (formatName != id)
-                        {
-                            doc.Save(Path.Combine(Path.GetDirectoryName(p), formatName + Path.GetExtension(p)));
-                            renamedIds[id] = formatName;
-                            File.Delete(p);
-                            return;
-                        }
-                    }
+                    XDocument doc = XDocument.Parse(content);                   
                     doc.Save(p);
-
-                });
-
-            //update id and refid which are renamed
-            if (!renamedIds.IsEmpty)
-            {
-                await Directory.EnumerateFiles(inputPath, "*.xml").ForEachInParallelAsync(
-                p =>
-                {
-                    var content = File.ReadAllText(p, Encoding.UTF8);
-                    renamedIds.Keys.OrderByDescending(Key => Key.Length).ToList().ForEach(id => content = content.Replace(id, renamedIds[id]));
-                    XDocument doc = XDocument.Parse(content);
-                    doc.Save(p);
-                    return Task.FromResult(1);
-                });
-            }            
+                });           
 
             // get friendly uid
             var uidMapping = new ConcurrentDictionary<string, string>();

--- a/src/Microsoft.Content.Build.Code2Yaml.Steps/PreprocessXml.cs
+++ b/src/Microsoft.Content.Build.Code2Yaml.Steps/PreprocessXml.cs
@@ -140,18 +140,12 @@
                                   where g.Count() > 1 && duplicate != null
                                   select (string)duplicate.Attribute("refid")).ToList();
 
-            ConsoleLogger.WriteLine(new LogEntry { Phase = StepName, Level = LogLevel.Info, Message = $"DuplicatedItems: {string.Join(",", duplicateItems)}" });
-            ConsoleLogger.WriteLine(new LogEntry { Phase = StepName, Level = LogLevel.Info, Message = $"Compound has items: {compounddefIdMapping.Keys.Count}" });
             //Get duplicate Ids when ignore case
             var results = duplicateItems.Where(id => compounddefIdMapping.ContainsKey(id)).Select(k => compounddefIdMapping.TryRemove(k, out _)).ToList();
-
-            ConsoleLogger.WriteLine(new LogEntry { Phase = StepName, Level = LogLevel.Info, Message = $"Compound has items: {compounddefIdMapping.Keys.Count}" });
             var duplicatedIds = compounddefIdMapping.GroupBy(k => k.Value.ToLower())
                              .Where(g => g.Count() > 1)
                              .Select(kg => kg.Select(kv => kv.Key))
                              .SelectMany(ke => ke);
-            ConsoleLogger.WriteLine(new LogEntry { Phase = StepName, Level = LogLevel.Info, Message = $"Compound has items: {compounddefIdMapping.Keys.Count}" });
-            ConsoleLogger.WriteLine(new LogEntry { Phase = StepName, Level = LogLevel.Info, Message = $"DuplicatedIds: {string.Join(",", duplicatedIds)}" });
 
             var extendedIdMaping = new ConcurrentDictionary<string, string>();
             await Directory.EnumerateFiles(inputPath, "*.xml").ForEachInParallelAsync(
@@ -254,7 +248,6 @@
                 return Task.FromResult(1);
             });
             context.SetSharedObject(Constants.ExtendedIdMappings, extendedIdMaping);
-            ConsoleLogger.WriteLine(new LogEntry { Phase = StepName, Level = LogLevel.Info, Message = $"ExtendedPath: {string.Join(",", extendedIdMaping.Keys.ToList())}" });
         }
 
         private static string RegularizeUid(string uid, IDictionary<string, string> memberMapping)

--- a/src/Microsoft.Content.Build.Code2Yaml.Steps/PreprocessXml.cs
+++ b/src/Microsoft.Content.Build.Code2Yaml.Steps/PreprocessXml.cs
@@ -107,12 +107,12 @@
                                   where g.Count() > 1 && duplicate != null
                                   select (string)duplicate.Attribute("refid")).ToList();
 
-            //Get duplicate Ids when ignore case
+            // Get duplicate Ids when ignore case
             var results = duplicateItems.Where(id => compounddefIdMapping.ContainsKey(id)).Select(k => compounddefIdMapping.TryRemove(k, out _)).ToList();
             var duplicatedIds = compounddefIdMapping.GroupBy(k => k.Value.ToLower())
                              .Where(g => g.Count() > 1)
                              .Select(kg => kg.Select(kv => kv.Key))
-                             .SelectMany(ke => ke);
+                             .SelectMany(ke => ke).ToList();
 
             var extendedIdMaping = new ConcurrentDictionary<string, string>();
             await Directory.EnumerateFiles(inputPath, "*.xml").ForEachInParallelAsync(
@@ -201,7 +201,7 @@
                 if (compounddefIdMapping.TryGetValue(fileName, out string formatedFileName))
                 {
                     formatedFileName = RegularizeUid(formatedFileName);
-                    if(duplicatedIds.Contains(fileName))
+                    if (duplicatedIds.Contains(fileName))
                     {
                         fileName = string.Format(Constants.RenamedFormat, formatedFileName, TryGetType(fileName));
                         extendedIdMaping[formatedFileName] = fileName;

--- a/src/Microsoft.Content.Build.Code2Yaml.Steps/ScanHierarchy.cs
+++ b/src/Microsoft.Content.Build.Code2Yaml.Steps/ScanHierarchy.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.Content.Build.Code2Yaml.Steps
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
@@ -29,6 +30,7 @@
                 throw new ApplicationException(string.Format("Key: {0} doesn't exist in build context", Constants.Config));
             }
 
+            var extendedIdMappings = context.GetSharedObject(Constants.ExtendedIdMappings) as ConcurrentDictionary<string, string>;
             string inputPath = StepUtility.GetProcessedXmlOutputPath(config.OutputPath);
 
             // Parse Index file
@@ -44,7 +46,7 @@
                                {
                                    Uid = uid,
                                    Name = (string)ele.Element("name"),
-                                   File = uid + Constants.XmlExtension,
+                                   File = extendedIdMappings.ContainsKey(uid) ? extendedIdMappings[uid] + Constants.XmlExtension : uid + Constants.XmlExtension,
                                    Type = type.Value,
                                }).ToDictionary(c => c.Uid);
             }

--- a/test/code2yaml.Tests/Code2YamlTest.cs
+++ b/test/code2yaml.Tests/Code2YamlTest.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Content.Build.Code2Yaml.Tests
             procedure.RunAsync(context).Wait();
 
             // assert
-            var outputPath = Path.Combine(outputFolder, "com.mycompany.app.App.yml");
+            var outputPath = Path.Combine(outputFolder, "com.mycompany.app.App(class).yml");
             Assert.True(File.Exists(outputPath));
             var model = YamlUtility.Deserialize<PageModel>(outputPath);
             Assert.Equal(9, model.Items.Count);
@@ -67,6 +67,8 @@ namespace Microsoft.Content.Build.Code2Yaml.Tests
             var item = model.Items.Find(i => i.Name == "App<T>");
             Assert.NotNull(item);
             Assert.Equal(MemberType.Class, item.Type);
+            Assert.Equal("com.mycompany.app.App", item.Uid);
+            Assert.Equal("com.mycompany.app.App(class).yml", item.Href);
             Assert.Equal("com.mycompany.app.App<T>", item.FullName);
             Assert.Equal("T", item.Syntax.TypeParameters[0].Name);
             Assert.Equal("<p>App's summary </p>", item.Summary.Replace("\r\n", "\n"));
@@ -123,11 +125,14 @@ public void checkIndentation() {
             Assert.Equal("<p>Not decoded for summary: `&lt;`, `&gt;` </p>", item.Summary);
             Assert.Equal("Decoded in remarks: `<`, `>`\n```Java\n//Decoded in code snippet of remarks: `<`, `>`\n```", item.Remarks.Replace("\r\n", "\n"));
 
-            var renamedPath = Path.Combine(outputFolder, "com.mycompany.app.App.testIfCode2YamlIsCorrectlyConvertFileNameAndIdToRegularizedCompoundNameForLongFileNamesThatWillBeConvertedToHashByDoxygen.yml");
-            Assert.True(File.Exists(renamedPath));
-            model = YamlUtility.Deserialize<PageModel>(renamedPath);
+            var checkNameUidFormatPath = Path.Combine(outputFolder, "com.mycompany.app.App.testIfCode2YamlIsCorrectlyConvertFileNameAndIdToRegularizedCompoundNameForLongFileNamesThatWillBeConvertedToHashByDoxygen.yml");
+            Assert.True(File.Exists(checkNameUidFormatPath));
+            model = YamlUtility.Deserialize<PageModel>(checkNameUidFormatPath);
             item = model.Items.Find(i => i.Uid == "com.mycompany.app.App.testIfCode2YamlIsCorrectlyConvertFileNameAndIdToRegularizedCompoundNameForLongFileNamesThatWillBeConvertedToHashByDoxygen");
             Assert.NotNull(item);
+
+            var checkExtendedTypePath = Path.Combine(outputFolder, "com.mycompany.app.app(namespace).yml");
+            Assert.True(File.Exists(checkExtendedTypePath));
         }
 
         public void Dispose()

--- a/test/code2yaml.Tests/TestData/test.java
+++ b/test/code2yaml.Tests/TestData/test.java
@@ -85,7 +85,8 @@ public class App<T> {
     }
 
     /**
-     * An Inner class to check if hash is corrected in file name and file content.
+     * An Inner class to test file name format and refid/id format.
+     * The fileName/refid/id should not contain `_` or hash or other that not exist in its origin name
      */
     public class testIfCode2YamlIsCorrectlyConvertFileNameAndIdToRegularizedCompoundNameForLongFileNamesThatWillBeConvertedToHashByDoxygen { 
     }

--- a/test/code2yaml.Tests/TestData/testDuplicate.java
+++ b/test/code2yaml.Tests/TestData/testDuplicate.java
@@ -1,0 +1,11 @@
+package com.mycompany.app.app;
+
+/**
+ * The namespace file name `com.mycompany.App.App` will be duplicated with class file name `com.mycompany.app.App` after renamed.
+ * For this case, `({type})` will be extended to file name.
+ * e.g. `com.mycompany.App.App(namespace)`, `com.mycompany.app.App(class)`.
+ * The href should be the file name that extended `({type})`.
+ * Uid should not be affected.
+ */
+public class testExtendTypeForDuplicateNames {
+}

--- a/test/code2yaml.Tests/code2yaml.Tests.csproj
+++ b/test/code2yaml.Tests/code2yaml.Tests.csproj
@@ -22,6 +22,9 @@
     <None Update="TestData\test.java">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+	<None Update="TestData\testDuplicate.java">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
1. Reverted the before changes for remove random id in file name as it's causing thread issue and will make build timeout.
2. Renamed `memberUidMapping` to `uidMapping` and make it contains all compounddefId and memberId
3. Add `compounddefIdMapping` which will only contains the compoundefid, it's used to check if renamed name will be duplicated. Seperated this mapping because memberUid will have much duplicated values when ignore case.
4. Remove .xml file which `kind` is `file` or `dir`
5. Add shared extendedIdMappings for file name that extended `({kind})` to safely correct file and uid mapping