### PR TITLE
use literal scalar style for summary to avoid extra empty newline whi…

### DIFF
--- a/src/Microsoft.Content.Build.Code2Yaml.DataContracts/ViewModel/ArticleItemYaml.cs
+++ b/src/Microsoft.Content.Build.Code2Yaml.DataContracts/ViewModel/ArticleItemYaml.cs
@@ -68,7 +68,7 @@
         [YamlMember(Alias = "package")]
         public string PackageName { get; set; }
 
-        [YamlMember(Alias = "summary", ScalarStyle = ScalarStyle.Literal)]
+        [YamlMember(Alias = "summary", ScalarStyle = ScalarStyle.DoubleQuoted)]
         public string Summary { get; set; }
 
         [YamlMember(Alias = "remarks")]

--- a/src/Microsoft.Content.Build.Code2Yaml.DataContracts/ViewModel/ArticleItemYaml.cs
+++ b/src/Microsoft.Content.Build.Code2Yaml.DataContracts/ViewModel/ArticleItemYaml.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.ComponentModel;
-
+    using YamlDotNet.Core;
     using YamlDotNet.Serialization;
 
     [Serializable]
@@ -68,7 +68,7 @@
         [YamlMember(Alias = "package")]
         public string PackageName { get; set; }
 
-        [YamlMember(Alias = "summary")]
+        [YamlMember(Alias = "summary", ScalarStyle = ScalarStyle.Literal)]
         public string Summary { get; set; }
 
         [YamlMember(Alias = "remarks")]

--- a/test/code2yaml.Tests/Code2YamlTest.cs
+++ b/test/code2yaml.Tests/Code2YamlTest.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Content.Build.Code2Yaml.Tests
             var outputPath = Path.Combine(outputFolder, "com.mycompany.app.App(class).yml");
             Assert.True(File.Exists(outputPath));
             var model = YamlUtility.Deserialize<PageModel>(outputPath);
-            Assert.Equal(9, model.Items.Count);
+            Assert.Equal(10, model.Items.Count);
 
             var item = model.Items.Find(i => i.Name == "App<T>");
             Assert.NotNull(item);
@@ -84,6 +84,10 @@ namespace Microsoft.Content.Build.Code2Yaml.Tests
             Assert.Equal(MemberType.Method, item.Type);
             Assert.Equal("<p>Test a list:<ul><li><p>first item</p></li><li><p>second item </p></li></ul></p>", item.Summary.Replace("\r\n", "\n"));
 
+            item = model.Items.Find(i => i.Name == "testCommentsWithHtmlTag()");
+            Assert.NotNull(item);
+            Assert.Equal("<p>Write the list with HTML tag in Summary:</p>\n<p>\n  <ul>\n    <li>\n      <p>first item </p>\n    </li>\n    <li>\n      <p>second item </p>\n    </li>\n  </ul>\n</p>", item.Summary.Replace("\r\n", "\n"));
+
             item = model.Items.Find(i => i.Name == "testCommentsWithApiNote()");
             Assert.NotNull(item);
             Assert.Equal(MemberType.Method, item.Type);
@@ -95,7 +99,7 @@ item.Remarks.Replace("\r\n", "\n"));
             item = model.Items.Find(i => i.Name == "testCommentsWithBr()");
             Assert.NotNull(item);
             Assert.Equal(MemberType.Method, item.Type);
-            Assert.Equal("<p>This is first line. <br />\n\n This is second line. </p>", item.Summary.Replace("\r\n", "\n"));
+            Assert.Equal("<p>This is first line. <br />\n This is second line. </p>", item.Summary.Replace("\r\n", "\n"));
 
             item = model.Items.Find(i => i.Name == "testCommentsWithExternalLink()");
             Assert.NotNull(item);

--- a/test/code2yaml.Tests/TestData/test.java
+++ b/test/code2yaml.Tests/TestData/test.java
@@ -23,6 +23,16 @@ public class App<T> {
     }
 
     /**
+     * <p>Write the list with HTML tag in Summary:</p>
+     * <ul>
+     *     <li>first item</li>
+     *     <li>second item</li>
+     * </ul>
+     */
+    public void testCommentsWithHtmlTag() {
+    }
+
+    /**
      * The **apiNote** section should be extracted into **remarks** property
      * @apiNote
      * ## examples\n


### PR DESCRIPTION
Issue: [45440](https://ceapex.visualstudio.com/Engineering/OPS%20Build%20Team/_workitems/edit/45440)
Change:
- Use literal scalar style for summary to avoid extra empty newline which will break html list format

Affect:
- The extra empty new line in summary will be removed
- The line break will be format to `\n` for summary with YamlUtility.Deserialize, but YamlUtility.Serialize still respects the line break of writer
- Not sure if any other effect exist..

[Preview Page](https://ppe.docs.microsoft.com/en-us/v-pegaoDocset0102091003/com.mycompany.app.app(class)?branch=master)