### PR TITLE
update to net462 and fix YamlDotNet vulnerability

### DIFF
--- a/src/Microsoft.Content.Build.Code2Yaml.ArticleGenerator/Microsoft.Content.Build.Code2Yaml.ArticleGenerator.csproj
+++ b/src/Microsoft.Content.Build.Code2Yaml.ArticleGenerator/Microsoft.Content.Build.Code2Yaml.ArticleGenerator.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Content.Build.Code2Yaml.ArticleGenerator</RootNamespace>
     <AssemblyName>Microsoft.Content.Build.Code2Yaml.ArticleGenerator</AssemblyName>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.Content.Build.Code2Yaml.Common/Microsoft.Content.Build.Code2Yaml.Common.csproj
+++ b/src/Microsoft.Content.Build.Code2Yaml.Common/Microsoft.Content.Build.Code2Yaml.Common.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Content.Build.Code2Yaml.Common</RootNamespace>
     <AssemblyName>Microsoft.Content.Build.Code2Yaml.Common</AssemblyName>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.Content.Build.Code2Yaml.Constants/Microsoft.Content.Build.Code2Yaml.Constants.csproj
+++ b/src/Microsoft.Content.Build.Code2Yaml.Constants/Microsoft.Content.Build.Code2Yaml.Constants.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Content.Build.Code2Yaml.Constants</RootNamespace>
     <AssemblyName>Microsoft.Content.Build.Code2Yaml.Constants</AssemblyName>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Content.Build.Code2Yaml.DataContracts/Microsoft.Content.Build.Code2Yaml.DataContracts.csproj
+++ b/src/Microsoft.Content.Build.Code2Yaml.DataContracts/Microsoft.Content.Build.Code2Yaml.DataContracts.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Content.Build.Code2Yaml.DataContracts</RootNamespace>
     <AssemblyName>Microsoft.Content.Build.Code2Yaml.DataContracts</AssemblyName>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.Content.Build.Code2Yaml.DeclarationGenerator/Microsoft.Content.Build.Code2Yaml.DeclarationGenerator.csproj
+++ b/src/Microsoft.Content.Build.Code2Yaml.DeclarationGenerator/Microsoft.Content.Build.Code2Yaml.DeclarationGenerator.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Content.Build.Code2Yaml.DeclarationGenerator</RootNamespace>
     <AssemblyName>Microsoft.Content.Build.Code2Yaml.DeclarationGenerator</AssemblyName>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.Content.Build.Code2Yaml.Doxyfile/Microsoft.Content.Build.Code2Yaml.Doxyfile.csproj
+++ b/src/Microsoft.Content.Build.Code2Yaml.Doxyfile/Microsoft.Content.Build.Code2Yaml.Doxyfile.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Content.Build.Code2Yaml.Doxyfile</RootNamespace>
     <AssemblyName>Microsoft.Content.Build.Code2Yaml.Doxyfile</AssemblyName>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Content.Build.Code2Yaml.NameGenerator/Microsoft.Content.Build.Code2Yaml.NameGenerator.csproj
+++ b/src/Microsoft.Content.Build.Code2Yaml.NameGenerator/Microsoft.Content.Build.Code2Yaml.NameGenerator.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Content.Build.Code2Yaml.NameGenerator</RootNamespace>
     <AssemblyName>Microsoft.Content.Build.Code2Yaml.NameGenerator</AssemblyName>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.Content.Build.Code2Yaml.Steps/Microsoft.Content.Build.Code2Yaml.Steps.csproj
+++ b/src/Microsoft.Content.Build.Code2Yaml.Steps/Microsoft.Content.Build.Code2Yaml.Steps.csproj
@@ -7,13 +7,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Content.Build.Code2Yaml.Steps</RootNamespace>
     <AssemblyName>Microsoft.Content.Build.Code2Yaml.Steps</AssemblyName>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.DocAsCode.YamlSerialization" Version="2.13.0.0" />
-    <Reference Include="YamlDotNet" Version="4.1.0.0" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Content.Build.Code2Yaml.ArticleGenerator\Microsoft.Content.Build.Code2Yaml.ArticleGenerator.csproj" />
     <ProjectReference Include="..\Microsoft.Content.Build.Code2Yaml.Common\Microsoft.Content.Build.Code2Yaml.Common.csproj" />
@@ -33,5 +29,8 @@
     <None Include="tools\libclang.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DocAsCode.YamlSerialization" Version="2.40.1" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Content.Build.Code2Yaml.Steps/packages.config
+++ b/src/Microsoft.Content.Build.Code2Yaml.Steps/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DocAsCode.YamlSerialization" version="2.13.0" targetFramework="net452" />
-  <package id="YamlDotNet.Signed" version="4.1.0" targetFramework="net452" />
+  <package id="Microsoft.DocAsCode.YamlSerialization" version="2.40.1" targetFramework="net462" />
 </packages>

--- a/src/Microsoft.Content.Build.Code2Yaml.Utility/Microsoft.Content.Build.Code2Yaml.Utility.csproj
+++ b/src/Microsoft.Content.Build.Code2Yaml.Utility/Microsoft.Content.Build.Code2Yaml.Utility.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Content.Build.Code2Yaml.Utility</RootNamespace>
     <AssemblyName>Microsoft.Content.Build.Code2Yaml.Utility</AssemblyName>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <ItemGroup>

--- a/src/code2yaml/App.config
+++ b/src/code2yaml/App.config
@@ -1,13 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/code2yaml/code2yaml.csproj
+++ b/src/code2yaml/code2yaml.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\shared\base.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -8,14 +7,13 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Microsoft.Content.Build.Code2Yaml</RootNamespace>
     <AssemblyName>code2yaml</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFramework>net462</TargetFramework>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -24,15 +22,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Program.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Content.Build.Code2Yaml.ArticleGenerator\Microsoft.Content.Build.Code2Yaml.ArticleGenerator.csproj">
@@ -60,12 +53,4 @@
       <Name>Microsoft.Content.Build.Code2Yaml.Steps</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/code2yaml/packages.config
+++ b/src/code2yaml/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
 </packages>

--- a/src/shared/base.props
+++ b/src/shared/base.props
@@ -9,7 +9,7 @@
     <!-- Note: unless explicitly specified, we will generate DLL -->
     <OutputType Condition=" '$(OutputType)' == '' ">Library</OutputType>
     <Prefer32Bit>false</Prefer32Bit>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <RestorePackages Condition=" '$(RestorePackages)' == '' ">true</RestorePackages>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/test/code2yaml.Tests/code2yaml.Tests.csproj
+++ b/test/code2yaml.Tests/code2yaml.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
DocFX fixed [CVE-2018-1000210](https://nvd.nist.gov/vuln/detail/CVE-2018-1000210) in 2.40.1. Related PR: https://github.com/dotnet/docfx/pull/3511

This PR updated DocFX's package to fix this issue, which requires the project to upgrade from net452 to net462.