### PR TITLE
group by id without type for inheritance

### DIFF
--- a/src/Microsoft.Content.Build.Code2Yaml.ArticleGenerator/BasicArticleGenerator.cs
+++ b/src/Microsoft.Content.Build.Code2Yaml.ArticleGenerator/BasicArticleGenerator.cs
@@ -377,7 +377,7 @@
 
             //yaml.Inheritance = idHash.ToDictionary(pair => nodeIdHash[pair.Key], pair => pair.Value.Select(n => nodeIdHash[n]).ToList());
             // var dict = idHash.ToDictionary(pair => nodeIdHash[pair.Key], pair => pair.Value.Select(n => nodeIdHash[n]).ToList());
-            var dict = idHash.GroupBy(pair => nodeIdHash[pair.Key]).ToDictionary(g => g.Key, g => g.SelectMany(p => p.Value).Select(n => nodeIdHash[n]).ToList());
+            var dict = idHash.GroupBy(pair => Regex.Replace(nodeIdHash[pair.Key], "<.*?>", string.Empty)).ToDictionary(g => g.Key, g => g.SelectMany(p => p.Value).Select(n => nodeIdHash[n]).ToList());
             yaml.Inheritance = new List<string>();
             string start = yaml.Uid;
             while (dict.ContainsKey(start))

--- a/test/code2yaml.Tests/Code2YamlTest.cs
+++ b/test/code2yaml.Tests/Code2YamlTest.cs
@@ -134,6 +134,8 @@ public void checkIndentation() {
             model = YamlUtility.Deserialize<PageModel>(checkNameUidFormatPath);
             item = model.Items.Find(i => i.Uid == "com.mycompany.app.App.testIfCode2YamlIsCorrectlyConvertFileNameAndIdToRegularizedCompoundNameForLongFileNamesThatWillBeConvertedToHashByDoxygen");
             Assert.NotNull(item);
+            Assert.True(item.Inheritance?.Count == 2);
+            Assert.Equal("NativeBase", item.Inheritance[1]);
 
             var checkExtendedTypePath = Path.Combine(outputFolder, "com.mycompany.app.app(namespace).yml");
             Assert.True(File.Exists(checkExtendedTypePath));

--- a/test/code2yaml.Tests/TestData/test.java
+++ b/test/code2yaml.Tests/TestData/test.java
@@ -102,6 +102,6 @@ public class App<T> {
      * An Inner class to test file name format and refid/id format.
      * The fileName/refid/id should not contain `_` or hash or other that not exist in its origin name
      */
-    public class testIfCode2YamlIsCorrectlyConvertFileNameAndIdToRegularizedCompoundNameForLongFileNamesThatWillBeConvertedToHashByDoxygen { 
+    public static class testIfCode2YamlIsCorrectlyConvertFileNameAndIdToRegularizedCompoundNameForLongFileNamesThatWillBeConvertedToHashByDoxygen extends NativeBase { 
     }
 }


### PR DESCRIPTION
the inheritance key is using id generated by doxygen which contains type for its parent, however, we are using uid which doesn't contains type to get inheritance, thus, inheritance is default inheritance.

e.g.
id = `com.microsoft.connecteddevices.AsyncOperation<T>.CompletionException`
uid = `com.microsoft.connecteddevices.AsyncOperation.CompletionException`