### PR TITLE
update  xref format in xsl template for docfx v3

### DIFF
--- a/src/Microsoft.Content.Build.Code2Yaml.Utility/TripleSlashCommentTransform.xsl
+++ b/src/Microsoft.Content.Build.Code2Yaml.Utility/TripleSlashCommentTransform.xsl
@@ -140,7 +140,9 @@
       <xsl:attribute name="data-throw-if-not-resolved">
         <xsl:text>false</xsl:text>
       </xsl:attribute>
-      <xsl:value-of select="current()"/>
+      <xsl:attribute name="data-raw-source">
+        <xsl:value-of select="current()"/>
+      </xsl:attribute>
     </xref>
   </xsl:template>
 

--- a/src/Microsoft.Content.Build.Code2Yaml.Utility/TripleSlashCommentTransformRemoveBr.xsl
+++ b/src/Microsoft.Content.Build.Code2Yaml.Utility/TripleSlashCommentTransformRemoveBr.xsl
@@ -138,7 +138,9 @@
       <xsl:attribute name="data-throw-if-not-resolved">
         <xsl:text>false</xsl:text>
       </xsl:attribute>
-      <xsl:value-of select="current()"/>
+      <xsl:attribute name="data-raw-source">
+        <xsl:value-of select="current()"/>
+      </xsl:attribute>
     </xref>
   </xsl:template>
 


### PR DESCRIPTION
Change from
 `<xref uid="" data-throw-if-not-resolved="false">ExecutionException</xref>`
to     
` <xref uid="" data-throw-if-not-resolved="false" data-raw-source="ExecutionException"></xref>` 